### PR TITLE
Make FakeGensimDict iterable

### DIFF
--- a/tmtoolkit/topicmod/_eval_tools.py
+++ b/tmtoolkit/topicmod/_eval_tools.py
@@ -68,3 +68,27 @@ class FakedGensimDict:
     @staticmethod
     def from_vocab(vocab):
         return FakedGensimDict(dict(zip(range(len(vocab)), vocab)))
+
+    def __iter__(self):
+        """Iterate over all tokens."""
+        return iter(self.keys())
+
+    # restore Py2-style dict API
+    iterkeys = __iter__
+
+    def iteritems(self):
+        return self.items()
+
+    def itervalues(self):
+        return self.values()
+
+    def keys(self):
+        """Get all stored ids.
+
+        Returns
+        -------
+        list of int
+            List of all token ids.
+
+        """
+        return list(self.token2id.values())


### PR DESCRIPTION
Due to changes to Gensim's Dictionary class, it is no more possible to calculate the `c_v` coherence measure given the parameters `topic_word_distrib`, `dtm`, `vocab` and `texts`. It results in the following TypeError:
```---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
~\lib\site-packages\tmtoolkit\topicmod\evaluate.py in metric_coherence_gensim(measure, topic_word_distrib, gensim_model, vocab, dtm, gensim_corpus, texts, top_n, return_coh_model, return_mean, **kwargs)
    405     coh_model_kwargs.update(kwargs)
    406 
--> 407     coh_model = gensim.models.CoherenceModel(**coh_model_kwargs)
    408 
    409     if return_coh_model:

~\lib\site-packages\gensim\models\coherencemodel.py in __init__(self, model, topics, texts, corpus, dictionary, window_size, keyed_vectors, coherence, topn, processes)
    213         self._accumulator = None
    214         self._topics = None
--> 215         self.topics = topics
    216 
    217         self.processes = processes if processes >= 1 else max(1, mp.cpu_count() - 1)

~\lib\site-packages\gensim\models\coherencemodel.py in topics(self, topics)
    428             new_topics = []
    429             for topic in topics:
--> 430                 topic_token_ids = self._ensure_elements_are_ids(topic)
    431                 new_topics.append(topic_token_ids)
    432 

~\lib\site-packages\gensim\models\coherencemodel.py in _ensure_elements_are_ids(self, topic)
    446     def _ensure_elements_are_ids(self, topic):
    447         ids_from_tokens = [self.dictionary.token2id[t] for t in topic if t in self.dictionary.token2id]
--> 448         ids_from_ids = [i for i in topic if i in self.dictionary]
    449         if len(ids_from_tokens) > len(ids_from_ids):
    450             return np.array(ids_from_tokens)

~\lib\site-packages\gensim\models\coherencemodel.py in <listcomp>(.0)
    446     def _ensure_elements_are_ids(self, topic):
    447         ids_from_tokens = [self.dictionary.token2id[t] for t in topic if t in self.dictionary.token2id]
--> 448         ids_from_ids = [i for i in topic if i in self.dictionary]
    449         if len(ids_from_tokens) > len(ids_from_ids):
    450             return np.array(ids_from_tokens)

TypeError: argument of type 'FakedGensimDict' is not iterable
```

To circumvent this problem, the class `FakedGensimDict` has been extended with code bits directly taken from the [Dictionary class](https://github.com/RaRe-Technologies/gensim/blob/develop/gensim/corpora/dictionary.py) (lines 109 to 132).